### PR TITLE
feat: support explicit base.channel:name zone addressing

### DIFF
--- a/custom_components/rehau_neasmart2/climate.py
+++ b/custom_components/rehau_neasmart2/climate.py
@@ -72,6 +72,8 @@ class RehauNeasmart2ZoneClimateEntity(RehauNeasmart2GenericClimateEntity):
         else:
             preset_mode = PRESET_STATES_MAPPING_REVERSE.get(state)
             if preset_mode is None:
+                if state == 0:
+                    return
                 _LOGGER.error(
                     "Error updating %s thermostat, unknown preset state: %s",
                     self._attr_unique_id,

--- a/custom_components/rehau_neasmart2/climate.py
+++ b/custom_components/rehau_neasmart2/climate.py
@@ -62,25 +62,27 @@ class RehauNeasmart2ZoneClimateEntity(RehauNeasmart2GenericClimateEntity):
     # Asynchronously updates the climate entity's state based on the zone data.
     async def async_update(self) -> None:
         zone_data = await self._device.get_zone_data()
-        if zone_data is not None and \
-                zone_data.get("state") is not None and \
-                zone_data.get("relative_humidity") is not None and \
-                zone_data.get("temperature") is not None and \
-                zone_data.get("setpoint") is not None:
-            preset_mode = PRESET_STATES_MAPPING_REVERSE.get(zone_data["state"])
+        if not zone_data:
+            _LOGGER.error(f"Error updating {self._attr_unique_id} thermostat")
+            return
+
+        state = zone_data.get("state")
+        if state is None:
+            self._attr_preset_mode = None
+        else:
+            preset_mode = PRESET_STATES_MAPPING_REVERSE.get(state)
             if preset_mode is None:
                 _LOGGER.error(
                     "Error updating %s thermostat, unknown preset state: %s",
                     self._attr_unique_id,
-                    zone_data["state"],
+                    state,
                 )
-                return
-            self._attr_preset_mode = preset_mode
-            self._attr_current_humidity = zone_data["relative_humidity"]
-            self._attr_current_temperature = zone_data["temperature"]
-            self._attr_target_temperature = zone_data["setpoint"]
-        else:
-            _LOGGER.error(f"Error updating {self._attr_unique_id} thermostat")
+            else:
+                self._attr_preset_mode = preset_mode
+
+        self._attr_current_humidity = zone_data.get("relative_humidity")
+        self._attr_current_temperature = zone_data.get("temperature")
+        self._attr_target_temperature = zone_data.get("setpoint")
 
     # Asynchronously sets the preset mode for the climate entity.
     async def async_set_preset_mode(self, preset_mode: str):

--- a/custom_components/rehau_neasmart2/config_flow.py
+++ b/custom_components/rehau_neasmart2/config_flow.py
@@ -59,6 +59,20 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
             if data.get("pumps_regs_mapping", "") != "" else []:
         if not pr.isdecimal() or int(pr) < 1 or int(pr) > 5:
             raise InvalidPumpIndex
+    # Validate new-format zone addresses where present.
+    for entry in data["zones"].split(","):
+        entry = entry.strip()
+        if ":" in entry:
+            try:
+                addr, _ = entry.split(":", 1)
+                parts = addr.split(".")
+                if len(parts) != 2:
+                    raise InvalidZoneAddress
+                base, channel = int(parts[0]), int(parts[1])
+                if not (1 <= base <= 5) or not (1 <= channel <= 12):
+                    raise InvalidZoneAddress
+            except ValueError:
+                raise InvalidZoneAddress
 
     # Create an instance of the Rehau Neasmart 2.0 Climate Control System hub.
     neasmart_climate_control_hub = hub.RehauNeasmart2ClimateControlSystem(
@@ -108,6 +122,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 errors["base"] = "too_many_extra_pump"
             except InvalidPumpIndex:
                 errors["base"] = "invalid_pump_index"
+            except InvalidZoneAddress:
+                errors["base"] = "invalid_zone_address"
             except Exception:  # pylint: disable=broad-except
                 _LOGGER.exception("Unexpected exception")
                 errors["base"] = "unknown"
@@ -141,3 +157,6 @@ class TooManyExtraPumps(HomeAssistantError):
 
 class InvalidPumpIndex(HomeAssistantError):
     """Error to indicate there are too many pumps."""
+
+class InvalidZoneAddress(HomeAssistantError):
+    """Error to indicate a zone address entry is malformed."""

--- a/custom_components/rehau_neasmart2/hub.py
+++ b/custom_components/rehau_neasmart2/hub.py
@@ -187,8 +187,7 @@ class RehauNeasmart2ClimateControlSystem:
         if json_response is None:
             return default
 
-        data = json_response.get(key)
-        if data is None:
+        if key not in json_response:
             self._set_gateway_online(
                 False,
                 (
@@ -196,6 +195,10 @@ class RehauNeasmart2ClimateControlSystem:
                     f"cannot access {key} in response: {json_response}"
                 ),
             )
+            return default
+
+        data = json_response[key]
+        if data is None:
             return default
 
         return data

--- a/custom_components/rehau_neasmart2/hub.py
+++ b/custom_components/rehau_neasmart2/hub.py
@@ -66,10 +66,14 @@ class RehauNeasmart2ClimateControlSystem:
             RehauNeasmart2Pump(int(pumps_topology[p]), self)
             for p in range(0, len(pumps_topology))
         ]
-        self.zones = [
-            RehauNeasmart2Zone((z // 12) + 1, z - (12 * (z // 12)) + 1, zones_name_array[z], self)
-            for z in range(0, len(zones_name_array))
-        ]
+        for z, entry in enumerate(zones_name_array):
+            entry = entry.strip()
+            if ":" in entry:
+                addr, name = entry.split(":", 1)
+                base_str, channel_str = addr.split(".")
+                self.zones.append(RehauNeasmart2Zone(int(base_str), int(channel_str), name.strip(), self))
+            else:
+                self.zones.append(RehauNeasmart2Zone((z // 12) + 1, z - (12 * (z // 12)) + 1, entry, self))
 
     @property
     def id(self) -> str:

--- a/custom_components/rehau_neasmart2/select.py
+++ b/custom_components/rehau_neasmart2/select.py
@@ -63,14 +63,14 @@ class RehauNeasmart2MasterGlobalModeSelect(RehauNeasmart2GenericSelect):
     async def async_update(self) -> None:
         """Asynchronously update the current global climate mode."""
         mode = await self._device.get_global_mode()
-        if mode is not None:
-            current_option = PRESET_CLIMATE_MODES_MAPPING_REVERSE.get(mode)
-            if current_option is None:
-                _LOGGER.error(f"Error updating global climate mode, invalid mode {mode}")
-                return
-            self._attr_current_option = current_option
-        else:
-            _LOGGER.error(f"Error updating global climate mode")  # Log an error if updating the mode fails.
+        if mode is None or mode == 0:
+            self._attr_current_option = None
+            return
+        current_option = PRESET_CLIMATE_MODES_MAPPING_REVERSE.get(mode)
+        if current_option is None:
+            _LOGGER.error(f"Error updating global climate mode, invalid mode {mode}")
+            return
+        self._attr_current_option = current_option
 
 # Specific class for Rehau Neasmart2 global climate state select entities.
 class RehauNeasmart2MasterGlobalStateSelect(RehauNeasmart2GenericSelect):
@@ -90,11 +90,11 @@ class RehauNeasmart2MasterGlobalStateSelect(RehauNeasmart2GenericSelect):
     async def async_update(self) -> None:
         """Asynchronously update the current global climate state."""
         state = await self._device.get_global_state()
-        if state is not None:
-            current_option = PRESET_STATES_MAPPING_REVERSE.get(state)
-            if current_option is None:
-                _LOGGER.error(f"Error updating global climate state, invalid state {state}")
-                return
-            self._attr_current_option = current_option
-        else:
-            _LOGGER.error(f"Error updating global climate state")  # Log an error if updating the state fails.
+        if state is None or state == 0:
+            self._attr_current_option = None
+            return
+        current_option = PRESET_STATES_MAPPING_REVERSE.get(state)
+        if current_option is None:
+            _LOGGER.error(f"Error updating global climate state, invalid state {state}")
+            return
+        self._attr_current_option = current_option

--- a/custom_components/rehau_neasmart2/select.py
+++ b/custom_components/rehau_neasmart2/select.py
@@ -63,11 +63,13 @@ class RehauNeasmart2MasterGlobalModeSelect(RehauNeasmart2GenericSelect):
     async def async_update(self) -> None:
         """Asynchronously update the current global climate mode."""
         mode = await self._device.get_global_mode()
-        if mode is None or mode == 0:
+        if mode is None:
             self._attr_current_option = None
             return
         current_option = PRESET_CLIMATE_MODES_MAPPING_REVERSE.get(mode)
         if current_option is None:
+            if mode == 0:
+                return
             _LOGGER.error(f"Error updating global climate mode, invalid mode {mode}")
             return
         self._attr_current_option = current_option
@@ -90,11 +92,13 @@ class RehauNeasmart2MasterGlobalStateSelect(RehauNeasmart2GenericSelect):
     async def async_update(self) -> None:
         """Asynchronously update the current global climate state."""
         state = await self._device.get_global_state()
-        if state is None or state == 0:
+        if state is None:
             self._attr_current_option = None
             return
         current_option = PRESET_STATES_MAPPING_REVERSE.get(state)
         if current_option is None:
+            if state == 0:
+                return
             _LOGGER.error(f"Error updating global climate state, invalid state {state}")
             return
         self._attr_current_option = current_option

--- a/custom_components/rehau_neasmart2/sensor.py
+++ b/custom_components/rehau_neasmart2/sensor.py
@@ -81,11 +81,7 @@ class RehauNeasmart2OutsideTemperatureSensor(RehauNeasmart2GenericSensor):
         self._attr_name = f"{self._device.name} Outside Temperature"
 
     async def async_update(self) -> None:
-        outside_temperature = await self._device.get_outside_temperature()
-        if outside_temperature is not None:
-            self._state = outside_temperature
-        else:
-            _LOGGER.error(f"Error updating {self._device.id}_outside_temperature")
+        self._state = await self._device.get_outside_temperature()
 
 
 class RehauNeasmart2FilteredOutsideTemperatureSensor(RehauNeasmart2GenericSensor):
@@ -98,11 +94,7 @@ class RehauNeasmart2FilteredOutsideTemperatureSensor(RehauNeasmart2GenericSensor
         self._attr_name = f"{self._device.name} Filtered Outside Temperature"
 
     async def async_update(self) -> None:
-        filtered_outside_temperature = await self._device.get_filtered_outside_temperature()
-        if filtered_outside_temperature is not None:
-            self._state = filtered_outside_temperature
-        else:
-            _LOGGER.error(f"Error updating {self._device.id}_filtered_outside_temperature")
+        self._state = await self._device.get_filtered_outside_temperature()
 
 
 class RehauNeasmart2ErrorsPresentSensor(RehauNeasmart2GenericSensor):
@@ -117,10 +109,7 @@ class RehauNeasmart2ErrorsPresentSensor(RehauNeasmart2GenericSensor):
 
     async def async_update(self) -> None:
         errors_present = await self._device.get_notification_errors()
-        if errors_present is not None:
-            self._state = PRESENCE_STATES[errors_present]
-        else:
-            _LOGGER.error(f"Error updating {self._device.id}_errors_presence")
+        self._state = PRESENCE_STATES[errors_present] if errors_present is not None else None
 
 
 class RehauNeasmart2WarningsPresentSensor(RehauNeasmart2GenericSensor):
@@ -135,10 +124,7 @@ class RehauNeasmart2WarningsPresentSensor(RehauNeasmart2GenericSensor):
 
     async def async_update(self) -> None:
         warnings_present = await self._device.get_notification_warnings()
-        if warnings_present is not None:
-            self._state = PRESENCE_STATES[warnings_present]
-        else:
-            _LOGGER.error(f"Error updating {self._device.id}_warnings_presence")
+        self._state = PRESENCE_STATES[warnings_present] if warnings_present is not None else None
 
 
 class RehauNeasmart2HintsPresentSensor(RehauNeasmart2GenericSensor):
@@ -153,10 +139,7 @@ class RehauNeasmart2HintsPresentSensor(RehauNeasmart2GenericSensor):
 
     async def async_update(self) -> None:
         hints_present = await self._device.get_notification_hints()
-        if hints_present is not None:
-            self._state = PRESENCE_STATES[hints_present]
-        else:
-            _LOGGER.error(f"Error updating {self._device.id}_hints_presence")
+        self._state = PRESENCE_STATES[hints_present] if hints_present is not None else None
 
 
 class RehauNeasmart2MixedGroupFlowTemperatureSensor(RehauNeasmart2GenericSensor):
@@ -169,11 +152,7 @@ class RehauNeasmart2MixedGroupFlowTemperatureSensor(RehauNeasmart2GenericSensor)
         self._attr_name = f"{self._device.name} Flow Temperature"
 
     async def async_update(self) -> None:
-        flow_temperature = await self._device.get_flow_temperature()
-        if flow_temperature is not None:
-            self._state = flow_temperature
-        else:
-            _LOGGER.error(f"Error updating {self._device.id}_mixedgroup_flow_temperature")
+        self._state = await self._device.get_flow_temperature()
 
 
 class RehauNeasmart2MixedGroupReturnTemperatureSensor(RehauNeasmart2GenericSensor):
@@ -186,11 +165,7 @@ class RehauNeasmart2MixedGroupReturnTemperatureSensor(RehauNeasmart2GenericSenso
         self._attr_name = f"{self._device.name} Return Temperature"
 
     async def async_update(self) -> None:
-        return_temperature = await self._device.get_return_temperature()
-        if return_temperature is not None:
-            self._state = return_temperature
-        else:
-            _LOGGER.error(f"Error updating {self._device.id}_mixedgroup_return_temperature")
+        self._state = await self._device.get_return_temperature()
 
 
 class RehauNeasmart2MixedGroupValveOpeningSensor(RehauNeasmart2GenericSensor):
@@ -202,11 +177,7 @@ class RehauNeasmart2MixedGroupValveOpeningSensor(RehauNeasmart2GenericSensor):
         self._attr_name = f"{self._device.name} Valve Opening"
 
     async def async_update(self) -> None:
-        valve_opening = await self._device.get_valve_opening_percentage()
-        if valve_opening is not None:
-            self._state = valve_opening
-        else:
-            _LOGGER.error(f"Error updating {self._device.id}_valve_opening")
+        self._state = await self._device.get_valve_opening_percentage()
 
 
 class RehauNeasmart2MixedGroupPumpStateSensor(RehauNeasmart2GenericSensor):
@@ -221,14 +192,14 @@ class RehauNeasmart2MixedGroupPumpStateSensor(RehauNeasmart2GenericSensor):
 
     async def async_update(self) -> None:
         pump_status = await self._device.get_pump_state()
-        if pump_status is not None:
-            mapped_state = BINARY_STATUSES.get(pump_status)
-            if mapped_state is None:
-                _LOGGER.error(f"Error updating {self._device.id}_mixedgroup_pump_state, invalid state {pump_status}")
-                return
-            self._state = mapped_state
-        else:
-            _LOGGER.error(f"Error updating {self._device.id}_mixedgroup_pump_state")
+        if pump_status is None:
+            self._state = None
+            return
+        mapped_state = BINARY_STATUSES.get(pump_status)
+        if mapped_state is None:
+            _LOGGER.error(f"Error updating {self._device.id}_mixedgroup_pump_state, invalid state {pump_status}")
+            return
+        self._state = mapped_state
 
 
 class RehauNeasmart2ExtraPumpStateSensor(RehauNeasmart2GenericSensor):
@@ -243,14 +214,14 @@ class RehauNeasmart2ExtraPumpStateSensor(RehauNeasmart2GenericSensor):
 
     async def async_update(self) -> None:
         pump_status = await self._device.get_pump_state()
-        if pump_status is not None:
-            mapped_state = BINARY_STATUSES.get(pump_status)
-            if mapped_state is None:
-                _LOGGER.error(f"Error updating {self._device.id}_extra_pump_state, invalid state {pump_status}")
-                return
-            self._state = mapped_state
-        else:
-            _LOGGER.error(f"Error updating {self._device.id}_extra_pump_state")
+        if pump_status is None:
+            self._state = None
+            return
+        mapped_state = BINARY_STATUSES.get(pump_status)
+        if mapped_state is None:
+            _LOGGER.error(f"Error updating {self._device.id}_extra_pump_state, invalid state {pump_status}")
+            return
+        self._state = mapped_state
 
 
 class RehauNeasmart2DehumidifierStateSensor(RehauNeasmart2GenericSensor):
@@ -261,11 +232,7 @@ class RehauNeasmart2DehumidifierStateSensor(RehauNeasmart2GenericSensor):
         self._attr_name = f"{self._device.name} Dehumidifiers State"
 
     async def async_update(self) -> None:
-        dehumidifier_status = await self._device.get_dehumidifier_state()
-        if dehumidifier_status is not None:
-            self._state = dehumidifier_status
-        else:
-            _LOGGER.error(f"Error updating {self._device.id}_dehumidifier_state")
+        self._state = await self._device.get_dehumidifier_state()
 
 
 class RehauNeasmart2ZoneHumidity(RehauNeasmart2GenericSensor):
@@ -280,10 +247,7 @@ class RehauNeasmart2ZoneHumidity(RehauNeasmart2GenericSensor):
 
     async def async_update(self) -> None:
         zone_data = await self._device.get_zone_data()
-        if zone_data is not None and zone_data.get("relative_humidity") is not None:
-            self._state = zone_data["relative_humidity"]
-        else:
-            _LOGGER.error(f"Error updating {self._attr_unique_id} thermostat")
+        self._state = zone_data.get("relative_humidity") if zone_data else None
 
 class RehauNeasmart2ZoneTemperature(RehauNeasmart2GenericSensor):
     device_class = SensorDeviceClass.TEMPERATURE
@@ -296,7 +260,4 @@ class RehauNeasmart2ZoneTemperature(RehauNeasmart2GenericSensor):
 
     async def async_update(self) -> None:
         zone_data = await self._device.get_zone_data()
-        if zone_data is not None and zone_data.get("temperature") is not None:
-            self._state = zone_data["temperature"]
-        else:
-            _LOGGER.error(f"Error updating {self._attr_unique_id} thermostat")
+        self._state = zone_data.get("temperature") if zone_data else None

--- a/custom_components/rehau_neasmart2/strings.json
+++ b/custom_components/rehau_neasmart2/strings.json
@@ -21,6 +21,7 @@
       "invalid_dehumidificator_index": "[%key:common::config_flow::error::invalid_dehumidificator_index%]",
       "too_many_extra_pump": "[%key:common::config_flow::error::too_many_extra_pump%]",
       "invalid_pump_index": "[%key:common::config_flow::error::invalid_pump_index%]",
+      "invalid_zone_address": "A zone address entry is malformed. Use base.channel:name (e.g. 1.3:Kitchen).",
       "unknown": "[%key:common::config_flow::error::unknown%]"
     },
     "abort": {

--- a/custom_components/rehau_neasmart2/translations/en.json
+++ b/custom_components/rehau_neasmart2/translations/en.json
@@ -11,6 +11,7 @@
             "invalid_dehumidificator_index": "Invalid dehumidificator index specified, valid indexes are between 1 and 9",
             "too_many_extra_pump": "Too many pumps specified, maximum is 5",
             "invalid_pump_index": "Invalid pump index specified, valid indexes are between 1 and 5",
+            "invalid_zone_address": "A zone address entry is malformed. Use base.channel:name (e.g. 1.3:Kitchen).",
             "unknown": "Unknown error"
         },
         "step": {


### PR DESCRIPTION
## Motivation

The current zone configuration parses entries as a comma-separated list of names, where the position in the list implicitly determines the base unit and channel via `(z // 12) + 1` for base and `z % 12 + 1` for channel.

This works for installations where all zones are on consecutive channels of a single base unit, but breaks down for multi-base setups with gaps in channel numbering — which are common when room thermostats are connected to a subset of available channels on each base.

My home setup is a worked example:
- Master base unit: channels 1, 3, 4, 5, 7, 8 (six zones, channels 2 and 6 unused for reasons best known to my plumber)
- Slave 1: channel 1 only
- Slave 2: channels 1 and 3

Configuring this today requires a 26-entry string with 17 empty placeholders to reach the right addresses, creating 17 phantom climate entities in HA that poll non-existent registers.

## Change

Introduces an optional `base.channel:name` format alongside the existing sequential format. Both can be mixed in the same config:

1.1:Landing,1.3:Master bedroom,2.1:Kitchen,3.1:Utility,3.3:Living room

If an entry contains `:`, it's parsed as `base.channel:name`. Otherwise the existing sequential behaviour applies, so anyone already using the integration sees no change.

Validation in `config_flow.py`: base in 1–5, channel in 1–12. Malformed entries surface as `invalid_zone_address`. Translations added for the new error code.

## Testing

Tested against your gateway add-on 0.2.9 in a dev environment, simulating a 3-base topology with non-contiguous channels via a synthetic Modbus master. All 9 configured zones materialised in HA with correct names and addresses, no phantom entities.

## Notes

- The implementation deliberately preserves the existing sequential format unchanged for backward compatibility.
-  I developed this change with assistance from Claude, in case that's relevant to your contribution preferences.